### PR TITLE
Initial MacVim support

### DIFF
--- a/osx/color-picker
+++ b/osx/color-picker
@@ -1,6 +1,9 @@
 #!/usr/bin/ruby
 
 color = ARGV[0]
+if color == ""
+	color = "#FFAABB"
+end
 
 red = color[1..2].to_i(16) * 257
 green = color[3..4].to_i(16) * 257

--- a/plugin/vCoolor.vim
+++ b/plugin/vCoolor.vim
@@ -290,7 +290,7 @@ function s:ExecPicker(hexColor)
     let l:comm = "yad --title=\"vCoolor\" --color --init-color=\"".a:hexColor."\" --on-top --skip-taskbar --center"
 
     if has("mac")
-        let l:comm = s:path . "/../osx/color-picker"
+        let l:comm = s:path . "/../osx/color-picker \"".a:hexColor."\""
     endif
 
     let s:newCol = toupper(system(l:comm))


### PR DESCRIPTION
This enables users of MacVim to use the basic color picker functions, per the comment on the Reddit post.
