### PR TITLE
Fix potential exception on OSX

### DIFF
--- a/osx/color-picker
+++ b/osx/color-picker
@@ -22,6 +22,7 @@ out = IO.popen [
  '-e', '  try',
  '-e', '    set col to (choose color default color my_color) as text',
  '-e', '  on error number -128 --',
+ '-e', '    set col to my_color as text',
  '-e', '  end try',
  '-e', 'end tell',
 ]


### PR DESCRIPTION
There was a potential error that could show up on OSX if the user closed the dialog with the X button. This suppresses that.
