### PR TITLE
Added RgbFrac format

### DIFF
--- a/autoload/vcoolor/convert.vim
+++ b/autoload/vcoolor/convert.vim
@@ -189,6 +189,26 @@ fun! vcoolor#convert#Rgb2RgbPerc(rgbCol) " {{{1
     return l:color
 
 endfun
+fun! vcoolor#convert#Rgb2RgbFrac(rgbCol) " {{{1
+    " Convert from rgb to rgb (fraction):
+    " 255, 0, 255 => 1.0, 0.0, 1.0
+
+    let l:rgbCol = substitute(a:rgbCol, " ", "", "g")
+    let l:rgbColL = split(l:rgbCol, ",")
+
+    let l:color = ""
+    for l:element in copy(l:rgbColL)
+        let l:rgbElem= printf('%.2f',l:element / 255.0)
+        if len(l:color) == 0
+            let l:color = l:rgbElem
+        else
+            let l:color = l:color.", ".l:rgbElem
+        endif
+    endfor
+
+    return l:color
+
+endfun
 fun! vcoolor#convert#RgbPerc2Hex(rgbPercCol) " {{{1
     " Convert from rgb (%) to hex:
     " 100%, 0%, 100% => #FF00FF
@@ -266,6 +286,16 @@ fun! vcoolor#convert#Hex2RgbPerc(hexCol) " {{{1
 
     let l:rgbCol = vcoolor#convert#Hex2Rgb(a:hexCol)
     let l:color = vcoolor#convert#Rgb2RgbPerc(l:rgbCol)
+
+    return l:color
+
+endfun
+fun! vcoolor#convert#Hex2RgbFrac(hexCol) " {{{1
+    " Convert from hex to rgb (frac):
+    " #FF00FF => 1.0, 0.0, 1.0
+
+    let l:rgbCol = vcoolor#convert#Hex2Rgb(a:hexCol)
+    let l:color = vcoolor#convert#Rgb2RgbFrac(l:rgbCol)
 
     return l:color
 

--- a/plugin/vCoolor.vim
+++ b/plugin/vCoolor.vim
@@ -37,7 +37,7 @@ let s:commandNames = [
 			\ "Rgb2Hex", "Rgb2RgbPerc", "Rgb2Hsl",
 			\ "RgbPerc2Hex", "RgbPerc2Rgb",
 			\ "Hex2Lit", "Hex2Rgb", "Hex2RgbPerc", "Hex2Hsl",
-			\ "Hsl2Rgb", "Hsl2Hex"
+			\ "Hsl2Rgb", "Hsl2Hex", "Rgb2RgbFrac"
 			\ ]
 for s:cn in s:commandNames
     if exists(":".s:cn."") != 2
@@ -269,6 +269,8 @@ function s:VCoolIns(type) " {{{1
 			execute ":normal ahsl(".vcoolor#convert#Hex2Hsl(l:newCol).")"
 		elseif a:type == 'ra'
 			execute ":normal argba(".vcoolor#convert#Hex2Rgb(l:newCol).", 1)"
+		elseif a:type == 'rf'
+			execute ":normal a".vcoolor#convert#Hex2RgbFrac(l:newCol)
 		endif
 	endif
 


### PR DESCRIPTION
Thanks for this super useful plugin!

For my use-case, I needed the RGB colours but in fractional form, e.g. 0.13, 0.45, 0.12. This can now be done with the command 
 
    :VCoolIns rf

Maybe this is useful for someone else too. 